### PR TITLE
run libstempo fitter to refit jumps

### DIFF
--- a/clean_files.ipynb
+++ b/clean_files.ipynb
@@ -187,7 +187,10 @@
     "        jpar = psr.pars()[idx[maxind]-1]\n",
     "        print('Setting {} as reference jump.\\n'.format(jpar))\n",
     "        psr[jpar].fit = False\n",
-    "        psr[jpar].val = 0"
+    "        psr[jpar].val = 0\n",
+    "\n",
+    "        # run libstempo fitter to refit jumps relative to new reference\n",
+    "        _ = psr.fit()"
    ]
   },
   {


### PR DESCRIPTION
`fix_jumps()` picks a new reference backend, if the original reference was filtered out (e.g. reference was a NG backend, but you selected EPTA data).  All jumps must be refit, so they are correct for this new reference.

I think Justin/Megan ran `tempo` to refit them at the busyweek.  This change calls `libstempo`'s fitter to refit without leaving the notebook.