### PR TITLE
add min_toas option to filter_psr()

### DIFF
--- a/dr2lite_utils.py
+++ b/dr2lite_utils.py
@@ -253,10 +253,14 @@ def filter_psr(psr, bw=1.1, dt=7, filter_dict=None, min_toas=10,
         if N>0 and N<min_toas:
             psr.deleted[mask] = True
             orphans.append([gr, N])
-    if verbose: print("backends marked as 'orphan': {}".format(orphans))
+    if verbose and len(orphans): print("backends marked as 'orphan': {}".format(orphans))
 
     # filter design matrix
     mask = np.logical_not(psr.deleted)
+    if not sum(mask):
+        print("all TOAs cut, returning original psr")
+        return psr
+
     M = psr.designmatrix()[mask, :]
     dpars = []
     for ct, (par, val) in enumerate(zip(psr.pars(), M.sum(axis=0)[1:])):

--- a/dr2lite_utils.py
+++ b/dr2lite_utils.py
@@ -253,7 +253,7 @@ def filter_psr(psr, bw=1.1, dt=7, filter_dict=None, min_toas=10,
         if N>0 and N<min_toas:
             psr.deleted[mask] = True
             orphans.append([gr, N])
-    if verbose: print("backends marked as 'orphan': {}".format(ophans))
+    if verbose: print("backends marked as 'orphan': {}".format(orphans))
 
     # filter design matrix
     mask = np.logical_not(psr.deleted)
@@ -286,7 +286,7 @@ def filter_psr(psr, bw=1.1, dt=7, filter_dict=None, min_toas=10,
 
 def make_dataset(psrdict, indir, outdir='partim_filtered',
                  frequency_filter=True, bw=1.1, dt=7, fmax=3000,
-                 tmin=0,
+                 tmin=0, min_toas=0,
                  plot=False, verbose=True):
     """make a filtered, DR2-lite style dataset of .par and .tim files
 
@@ -328,7 +328,7 @@ def make_dataset(psrdict, indir, outdir='partim_filtered',
         else:
             ff = frequency_filter
         psr = filter_psr(psr, filter_dict=filters, frequency_filter=ff,
-                         bw=bw, dt=dt, fmax=fmax,
+                         bw=bw, dt=dt, fmax=fmax, min_toas=min_toas,
                          plot=plot, verbose=verbose)
         toas_keep = psr.toas()[~psr.deletedmask()]
         try:

--- a/dr2lite_utils.py
+++ b/dr2lite_utils.py
@@ -53,7 +53,7 @@ def clean_par(infile, outfile):
 
 def combine_tim(infile, outfile):
     """combine all .tim files into one super .tim file
-    
+
     :param infiles: DR2 .tim file that links to other actual .tim files
     :param outfile: output .tim file
     """
@@ -138,15 +138,19 @@ def fix_jumps(psr, verbose=True):
         # find JUMP group with lowest weighted variance
         maxind = np.argmax([(1/psr.toaerrs[mask][np.flatnonzero(M[:, ix])]**2).sum() for ix in idx])
         jpar = psr.pars()[idx[maxind]-1]
+        ref = psr[jpar].val  # original jump val
         if verbose: print('Setting {} as reference jump.'.format(jpar))
         psr[jpar].fit = False
         psr[jpar].val = 0
 
-        # run libstempo fitter to refit jumps relative to new reference
-        try:
-            _ = psr.fit()
-        except np.linalg.LinAlgError:
-            print("LinAlgError in libstempo.tempopulsar.fit(), skipping refit")
+        # get remaining JUMPS (need to be refit)
+        idx = [ct for ct, p in enumerate(psr.pars()) if 'JUMP' in p]
+
+        # manually re-reference each jump
+        for ix in idx:
+            this_par = psr.pars()[ix]
+            if psr[this_par].fit:
+                psr[this_par].val -= ref
 
 
 def get_dm_bins(toas, dt=7):


### PR DESCRIPTION
New option `min_toas` in `dr2lite_utils.filter_psr()` automatically checks the number of TOAs in each backend after performing flag and frequency filters.  It will mark backends with too few TOAs as "orphans" and remove them.

Previously, this had to be done manually... note that removing "orphan" backends may affect frequency coverage.